### PR TITLE
Fix: Production build never ends.

### DIFF
--- a/src/processors/manifest.ts
+++ b/src/processors/manifest.ts
@@ -48,7 +48,8 @@ export class ManifestProcessor {
     try {
       this.packageJsonPath = normalizePath(join(process.cwd(), 'package.json'))
     } catch (error) {}
-    this.watchPackageJson(this.packageJsonPath)
+    if (options.viteConfig.build.watch)
+      this.watchPackageJson(this.packageJsonPath)
     this.loadManifest(manifestAbsolutPath)
   }
 


### PR DESCRIPTION
### Background
Fix : [#17](https://github.com/Jervis2049/vite-plugin-crx-mv3/issues/17)

### Changes
It seems that we don't need to watch package.json in non-watch mode.
I added a condition to make sure that only watch in watch mode.
```
if (options.viteConfig.build.watch)
```
The value could be null/true or object 



