### PR TITLE
Fix special characters in manifest name 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export default function crxMV3(options: Partial<Options> = {}): Plugin {
       socket = ws
     })
     server.on('upgrade', function upgrade(request, socket, head) {
-      if (request.url === `/${manifest.name}/crx`) {
+      if (request.url === `/${encodeURI(manifest.name)}/crx`) {
         wss.handleUpgrade(request, socket, head, function done(ws) {
           wss.emit('connection', ws, request)
         })


### PR DESCRIPTION
**Problem:**
If we have space, the `request.url` will not match the `manifest.name` and the reload mechanism will not work.

Issue:
![image](https://github.com/Jervis2049/vite-plugin-crx-mv3/assets/16647736/5ab8b53d-fb9e-45e6-9e81-e2797d7f9785)

But after checking the manifest name with `encodeURI`, the problem will be fixed:
![image](https://github.com/Jervis2049/vite-plugin-crx-mv3/assets/16647736/e58be557-1776-4260-a0da-f7ab67b37c07)


Thanks for your great plugin