### PR TITLE
fix: preserve original source maps

### DIFF
--- a/src/processors/manifest.ts
+++ b/src/processors/manifest.ts
@@ -196,7 +196,7 @@ export class ManifestProcessor {
     )
     code = await serviceWorkParse.generageDynamicImports(context, this, code)
 
-    return data + code
+    return { code: data + code, map: null}; 
   }
 
   public async generateDevScript(context, port, reloadPage) {


### PR DESCRIPTION
This change gets source maps working.

Because the content script code isn't getting transformed beyond removing comments, we can preserve the original source maps by returning null according to the rollup docs here.

https://rollupjs.org/plugin-development/#source-code-transformations

This should also address #35 — not seeing this error anymore after implementing this change.